### PR TITLE
Freeslick support to use it with Oracle.

### DIFF
--- a/jdbc/src/main/scala/akka/persistence/jdbc/query/dao/ByteArrayReadJournalDao.scala
+++ b/jdbc/src/main/scala/akka/persistence/jdbc/query/dao/ByteArrayReadJournalDao.scala
@@ -68,7 +68,7 @@ trait OracleReadJournalDao extends ReadJournalDao {
 
   import profile.api._
 
-  private lazy val isOracleDriver = profile.getClass.getName.contains("OracleDriver")
+  private lazy val isOracleDriver = profile.getClass.getName.contains("Oracle")
 
   abstract override def allPersistenceIdsSource(max: Long): Source[String, NotUsed] = {
     if (isOracleDriver) {

--- a/jdbc/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotTables.scala
+++ b/jdbc/src/main/scala/akka/persistence/jdbc/snapshot/dao/SnapshotTables.scala
@@ -24,7 +24,7 @@ object SnapshotTables {
   case class SnapshotRow(persistenceId: String, sequenceNumber: Long, created: Long, snapshot: Array[Byte])
 
   def isOracleDriver(profile: JdbcProfile) =
-    profile.getClass.getName.contains("OracleDriver")
+    profile.getClass.getName.contains("Oracle")
 }
 
 trait SnapshotTables {

--- a/jdbc/src/test/resources/freeslick-oracle-application.conf
+++ b/jdbc/src/test/resources/freeslick-oracle-application.conf
@@ -1,0 +1,83 @@
+# Copyright 2016 Dennis Vriend
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include "general.conf"
+include "docker.conf"
+
+jdbc-journal {
+  tables {
+    journal {
+      tableName = "journal"
+      schemaName = "SYSTEM"
+    }
+  }
+
+  slick = ${slick}
+  slick.db.numThreads = 8
+  slick.db.maxConnections = 5
+  slick.db.minConnections = 1
+  slick.db.connectionTimeout = 1800000 // 30 minutes
+}
+
+# the akka-persistence-snapshot-store in use
+jdbc-snapshot-store {
+  tables {
+    snapshot {
+      tableName = "snapshot"
+      schemaName = "SYSTEM"
+    }
+  }
+
+  slick = ${slick}
+  slick.db.numThreads = 8
+  slick.db.maxConnections = 5
+  slick.db.minConnections = 1
+  slick.db.connectionTimeout = 1800000 // 30 minutes
+}
+
+# the akka-persistence-query provider in use
+jdbc-read-journal {
+
+  refresh-interval = "100ms"
+
+  max-buffer-size = "500"
+
+  tables {
+    journal {
+      tableName = "journal"
+      schemaName = "SYSTEM"
+    }
+  }
+
+  slick = ${slick}
+  slick.db.numThreads = 100
+  slick.db.maxConnections = 10
+  slick.db.minConnections = 1
+  slick.db.connectionTimeout = 1800000 // 30 minutes
+}
+
+slick {
+  driver = "freeslick.OracleProfile$"
+  db {
+    host = ${docker.host}
+    host = ${?ORACLE_HOST}
+    url = "jdbc:oracle:thin:@//"${slick.db.host}":1521/xe"
+    user = "system"
+    user = ${?ORACLE_USER}
+    password = "oracle"
+    password = ${?ORACLE_PASSWORD}
+    driver = "oracle.jdbc.OracleDriver"
+    connectionTestQuery = "SELECT 1 FROM DUAL"
+  }
+}

--- a/jdbc/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalPerfSpec.scala
+++ b/jdbc/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalPerfSpec.scala
@@ -94,4 +94,14 @@ class OracleJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("orac
   override def measurementIterations: Int = 1
 }
 
+class FreeslickOracleJournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("freeslick-oracle-application.conf"), Oracle()) {
+  override implicit def pc: PatienceConfig = PatienceConfig(timeout = 10.minutes)
+
+  override def eventsCount: Int = 100
+
+  override def awaitDurationMillis: Long = 10.minutes.toMillis
+
+  override def measurementIterations: Int = 1
+}
+
 class H2JournalPerfSpec extends JdbcJournalPerfSpec(ConfigFactory.load("h2-application.conf"), H2())

--- a/jdbc/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalSpec.scala
+++ b/jdbc/src/test/scala/akka/persistence/jdbc/journal/JdbcJournalSpec.scala
@@ -71,4 +71,6 @@ class MySQLJournalSpec extends JdbcJournalSpec(ConfigFactory.load("mysql-applica
 
 class OracleJournalSpec extends JdbcJournalSpec(ConfigFactory.load("oracle-application.conf"), Oracle())
 
+class FreeslickOracleJournalSpec extends JdbcJournalSpec(ConfigFactory.load("freeslick-oracle-application.conf"), Oracle())
+
 class H2JournalSpec extends JdbcJournalSpec(ConfigFactory.load("h2-application.conf"), H2())

--- a/jdbc/src/test/scala/akka/persistence/jdbc/query/AllPersistenceIdsTest.scala
+++ b/jdbc/src/test/scala/akka/persistence/jdbc/query/AllPersistenceIdsTest.scala
@@ -66,4 +66,6 @@ class MySQLScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("mysql-appli
 
 class OracleScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
 
+class FreeslickOracleScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("freeslick-oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
+
 class H2ScalaAllPersistenceIdsTest extends AllPersistenceIdsTest("h2-application.conf") with ScalaJdbcReadJournalOperations with H2Cleaner

--- a/jdbc/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
+++ b/jdbc/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByPersistenceIdTest.scala
@@ -136,4 +136,6 @@ class MySQLScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersiste
 
 class OracleScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
 
+class FreeslickOracleScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("freeslick-oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
+
 class H2ScalaCurrentEventsByPersistenceIdTest extends CurrentEventsByPersistenceIdTest("h2-application.conf") with ScalaJdbcReadJournalOperations with H2Cleaner

--- a/jdbc/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
+++ b/jdbc/src/test/scala/akka/persistence/jdbc/query/CurrentEventsByTagTest.scala
@@ -161,4 +161,6 @@ class MySQLScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("mysql-app
 
 class OracleScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
 
+class FreeslickOracleScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("freeslick-oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
+
 class H2ScalaCurrentEventsByTagTest extends CurrentEventsByTagTest("h2-application.conf") with ScalaJdbcReadJournalOperations with H2Cleaner

--- a/jdbc/src/test/scala/akka/persistence/jdbc/query/CurrentPersistenceIdsTest.scala
+++ b/jdbc/src/test/scala/akka/persistence/jdbc/query/CurrentPersistenceIdsTest.scala
@@ -46,4 +46,6 @@ class MySQLScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("mys
 
 class OracleScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
 
+class FreeslickOracleScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("freeslick-oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
+
 class H2ScalaCurrentPersistenceIdsTest extends CurrentPersistenceIdsTest("h2-application.conf") with ScalaJdbcReadJournalOperations with H2Cleaner

--- a/jdbc/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
+++ b/jdbc/src/test/scala/akka/persistence/jdbc/query/EventsByPersistenceIdTest.scala
@@ -219,4 +219,6 @@ class MySQLScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("mys
 
 class OracleScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
 
+class FreeslickOracleScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("freeslick-oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
+
 class H2ScalaEventsByPersistenceIdTest extends EventsByPersistenceIdTest("h2-application.conf") with ScalaJdbcReadJournalOperations with H2Cleaner

--- a/jdbc/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
+++ b/jdbc/src/test/scala/akka/persistence/jdbc/query/EventsByTagTest.scala
@@ -262,4 +262,6 @@ class MySQLScalaEventByTagTest extends EventsByTagTest("mysql-application.conf")
 
 class OracleScalaEventByTagTest extends EventsByTagTest("oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
 
+class FreeslickOracleScalaEventByTagTest extends EventsByTagTest("freeslick-oracle-application.conf") with ScalaJdbcReadJournalOperations with OracleCleaner
+
 class H2ScalaEventsByTagTest extends EventsByTagTest("h2-application.conf") with ScalaJdbcReadJournalOperations with H2Cleaner

--- a/jdbc/src/test/scala/akka/persistence/jdbc/serialization/StoreOnlySerializableMessagesTest.scala
+++ b/jdbc/src/test/scala/akka/persistence/jdbc/serialization/StoreOnlySerializableMessagesTest.scala
@@ -132,4 +132,6 @@ class MySQLStoreOnlySerializableMessagesTest extends StoreOnlySerializableMessag
 
 class OracleStoreOnlySerializableMessagesTest extends StoreOnlySerializableMessagesTest("oracle-application.conf", Oracle())
 
+class FreeslickOracleStoreOnlySerializableMessagesTest extends StoreOnlySerializableMessagesTest("freeslick-oracle-application.conf", Oracle())
+
 class H2StoreOnlySerializableMessagesTest extends StoreOnlySerializableMessagesTest("h2-application.conf", H2())

--- a/jdbc/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStoreSpec.scala
+++ b/jdbc/src/test/scala/akka/persistence/jdbc/snapshot/JdbcSnapshotStoreSpec.scala
@@ -50,4 +50,6 @@ class MySQLSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("m
 
 class OracleSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("oracle-application.conf"), Oracle())
 
+class FreeslickOracleSnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("freeslick-oracle-application.conf"), Oracle())
+
 class H2SnapshotStoreSpec extends JdbcSnapshotStoreSpec(ConfigFactory.load("h2-application.conf"), H2())

--- a/paradox/src/main/paradox/jdbc.md
+++ b/paradox/src/main/paradox/jdbc.md
@@ -38,11 +38,9 @@ Gradle
     @@@
 
 Please note [PR #75 - Removed binary dependency on slick-extensions](https://github.com/dnvriend/akka-persistence-jdbc/pull/75),
-if you are using the Oracle driver, you must have a [Lightbend subscription](https://www.lightbend.com/platform/subscription).
+if you are using the Oracle driver from slick-extensions, you must have a [Lightbend subscription](https://www.lightbend.com/platform/subscription).
 I have misinterpreted Lightbend open sourcing slick-extensions 3.1.0 as a change to the license, it didn't so you __cannot__ use it
 for free.
-
-If using Oracle, you'll also need the Slick Oracle driver:
 
 ```
 // to resolve the slick-extensions you need the following repo
@@ -50,6 +48,14 @@ resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/maven-rel
 
 libraryDependencies += "com.typesafe.slick" %% "slick-extensions" % "3.1.0"
 ```
+
+If you do not have subscription you may use [freeslick](https://github.com/smootoo/freeslick), because it provides a free open-source driver for Oracle:
+
+```
+libraryDependencies += "org.suecarter" %% "freeslick" % "3.1.1.1"
+```
+
+
 
 ## Contribution policy
 
@@ -76,6 +82,7 @@ Configure `slick`:
   - `slick.driver.MySQLDriver$`
   - `slick.driver.H2Driver$`
   - `com.typesafe.slick.driver.oracle.OracleDriver$`
+  - `freeslick.OracleProfile$`
 
 ## Database Schema
 
@@ -103,8 +110,11 @@ Postgres
 MySQL
 :   @@snip[application.conf](/../../../../jdbc/src/test/resources/mysql-application.conf)
 
-Oracle
+Oracle (with slick-extensions)
 :   @@snip[application.conf](/../../../../jdbc/src/test/resources/oracle-application.conf)
+
+Oracle (with freeslick)
+:   @@snip[application.conf](/../../../../jdbc/src/test/resources/freeslick-oracle-application.conf)
     
 H2
 :   @@snip[application.conf](/../../../../jdbc/src/test/resources/h2-application.conf)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,6 +31,7 @@ object Dependencies {
       libraryDependencies ++= Seq(
         "com.typesafe.slick" %% "slick" % SlickVersion,
         "com.typesafe.slick" %% "slick-extensions" % "3.1.0" % Test,
+        "org.suecarter" %% "freeslick" % "3.1.1.1" % Test,
         "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion exclude("com.zaxxer", "HikariCP-java6"),
         "com.zaxxer" % "HikariCP" % HikariCPVersion,
         "org.postgresql" % "postgresql" % "9.4.1212" % Test,


### PR DESCRIPTION
I've added freeslick Oracle driver support to get rid of license issue with slick-extensions. While next slick is not released with Oracle driver included, projects may benefit to go production with freeslick. 